### PR TITLE
商品情報の削除

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,7 +1,7 @@
 class ProductsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update]
-  before_action :set_product, only: [:show,:edit, :update] #多分後でいる, :destroy
-  before_action :contributor_confirmation, only: [:edit, :update] #, :destroy
+  before_action :set_product, only: [:show,:edit, :update, :destroy] 
+  before_action :contributor_confirmation, only: [:edit, :update, :destroy] 
 
   def index
     @products = Product.all.order("created_at DESC")
@@ -31,6 +31,14 @@ class ProductsController < ApplicationController
       redirect_to root_path
     else
       render :edit
+    end
+  end
+
+  def destroy
+    if @product.destroy
+      redirect_to root_path
+    else
+      render :show
     end
   end
 

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -27,7 +27,7 @@
      <% if current_user.id == @product.user_id %>
      <%= link_to "商品の編集", edit_product_path(@product.id), method: :get, class: "item-red-btn" %>
      <p class="or-text">or</p>
-     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+     <%= link_to "削除", product_path(@product.id), method: :delete, class:"item-destroy" %>
      <%else%>
      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
      <% end %>


### PR DESCRIPTION
# what
商品情報削除機能実装
# why
商品削除機能実装の為

ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/87b31833f56607be9002f3d31faefde4